### PR TITLE
Move TypeScript types to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "eslint": "^1.10.3",
     "mocha": "^2.4.5",
     "publish-please": "^2.2.0"
-  },
-  "dependencies": {
     "@types/error-stack-parser": "^1.3.18",
     "@types/lodash": "^4.14.72",
+  },
+  "dependencies": {
     "callsite": "^1.0.0",
     "chalk": "^2.4.0",
     "error-stack-parser": "^1.3.3",


### PR DESCRIPTION
Moving TypeScript @types to devDependencies so that downstream projects that consume
this library don't pull in LoDash 4 types when that project uses both
lodash 3.10 and individual functions from lodash 4 as it transitions from Lodash 3 to 4.