### PR TITLE
Remove deprecated @types/error-stack-parser dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "callsite-record",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17,14 +17,6 @@
           "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
           "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
         }
-      }
-    },
-    "@types/error-stack-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/error-stack-parser/-/error-stack-parser-2.0.0.tgz",
-      "integrity": "sha512-O2ZQvaCuvqgpSOFzHST/VELij9sm5P84bouCz6z8DysloeY47JpeUyvv00TE0LrZPsG2qleUK00anUaLsvUMHQ==",
-      "requires": {
-        "error-stack-parser": "*"
       }
     },
     "@types/lodash": {
@@ -750,14 +742,6 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "error-stack-parser": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
-      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
-      "requires": {
-        "stackframe": "^1.1.1"
       }
     },
     "es5-ext": {
@@ -3055,11 +3039,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "stackframe": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
-      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
     },
     "string-width": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "@devexpress/error-stack-parser": "^2.0.6",
-    "@types/error-stack-parser": "^2.0.0",
     "@types/lodash": "^4.14.72",
     "callsite": "^1.0.0",
     "chalk": "^2.4.0",


### PR DESCRIPTION
As this dependency was deprecated, everyone installing `callsite-record` will see a deprecation warning. As the corresponding dependency [includes type definitions](https://github.com/stacktracejs/error-stack-parser/blob/v2.0.6/error-stack-parser.d.ts) in the version used here, there is no need for this dependency.

Fixes #14 