### PR TITLE
feat: added converting a string url to an instance of the URL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,6 +78,14 @@ function processFrames (stackFrames, processFn) {
     return processFn ? stackFrames.map(processFn) : stackFrames;
 }
 
+function getFilePath (filename) {
+  try {
+    return new URL(filename);
+  }
+  catch (_) {
+    filename;
+  }
+}
 
 // CallsiteRecord
 var CallsiteRecord = function (filename, lineNum, callsiteFrameIdx, stackFrames) {
@@ -215,16 +223,19 @@ CallsiteRecord.prototype._renderRecord = function (fileContent, opts) {
 };
 
 CallsiteRecord.prototype.renderSync = function (opts) {
-    var fileContent = fs.readFileSync(this.filename).toString();
+    var filePath    = getFilePath(this.filename);
+    var fileContent = fs.readFileSync(filePath).toString();
 
     return this._renderRecord(fileContent, opts);
 };
 
 CallsiteRecord.prototype.render = function (opts) {
     var record = this;
-
+    
     return new Promise(function (resolve, reject) {
-        fs.readFile(record.filename, function (err, fileContent) {
+        var filePath = getFilePath(record.filename);
+
+        fs.readFile(filePath, function (err, fileContent) {
             if (err)
                 reject(err);
             else


### PR DESCRIPTION
When we run scripts with module type `filename` has protocol `file:///`. `readFile` doesn't accept this format but [it accepts the URL instance](readFile). In this case, it needs to transform `filename` to the URL instances.